### PR TITLE
fix: Pong Saver url

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -88,7 +88,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 
 > PongSaver is an macOS screensaver/clock which keeps time by using the score of a game of Pong. The left side wins once an hour, and the right side wins once a minute.
 
-[![](screenshots/pongSaver.png)](http://rogueamoeba.com/freebies/)
+[![](screenshots/pongSaver.png)](https://mikeash.com/software/pongsaver/)
 
 ### Textify Me
 


### PR DESCRIPTION
Hey! 😃 

Just wanted to fix the Pong Saver URL.

The author explains itself:

> I wrote PongSaver while working at Rogue Amoeba way back in 2005. In 2017, they retired it from their lineup and gave it back to me. Now it lives here on my site.

Great list you got there, thanks! 👍 