### PR TITLE
Screensson URL Fix

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -168,7 +168,7 @@ Free
 
 Donationware
 
-[![](screenshots/screensson.png)](http://www.saver.is/#screensson)
+[![](screenshots/screensson.png)](http://www.siggieggertsson.com/Saver-Screensson)
 
 ### Emoji Saver
 


### PR DESCRIPTION
Previous URL linked to defunct site. New URL links to author's new web site.